### PR TITLE
Meta data

### DIFF
--- a/fabstract/Bauer_A_InjBaireNat/fabstract.lean
+++ b/fabstract/Bauer_A_InjBaireNat/fabstract.lean
@@ -10,16 +10,22 @@ namespace Bauer_A_InjBaireNat
 
 -- we construct a partial combinatory algebra based on
 -- infinite-time Turing machines
-constant IITM : PCA
+undefined_const IITM : PCA :=
+{description := "infinite time turing machine",
+ doi := []}
 
 def T := RT IITM
 
 definition N := T.nno.underlying_object
 definition Baire := (T.exponent N N).underlying_object
 
-constant Baire_to_N : T.underlying_category.hom Baire N
+undefined_const Baire_to_N : (T.underlying_category.hom Baire N) :=
+{description := "",
+ doi := []}
 
-axiom Baire_to_N_is_mono : monomorphism Baire_to_N
+unproved_theorem Baire_to_N_is_mono : (monomorphism Baire_to_N) :=
+{description := "",
+ doi := []}
 
 open result
 
@@ -31,5 +37,8 @@ def fabstract : meta_data := {
               Construction Baire_to_N,
               Proof Baire_to_N_is_mono]
 }
+
+#print axioms fabstract
+#print PCA._meta_data
 
 end Bauer_A_InjBaireNat

--- a/fabstract/Bauer_A_InjBaireNat/realizability.lean
+++ b/fabstract/Bauer_A_InjBaireNat/realizability.lean
@@ -2,12 +2,19 @@
 -- so we include partial formalization here. Eventually this should be
 -- moved to folklore.
 
-import folklore.toposes
+import ...meta_data folklore.toposes
 
-noncomputable theory
+-- there are some issues with parsing user-defined commands right now that make this line necessary
+run_cmd tactic.skip
 
+-- TODO (@andrejbauer): give real descriptions and dois
 -- missing definition of what a PCA is
-constant PCA : Type
+undefined_const PCA : Type :=
+{description := "partial combinatory algebra",
+ doi := ["https://ncatlab.org/nlab/show/partial+combinatory+algebra"]}
 
+-- TODO (@rlewis1988): fix binding power so that parens around the type aren't needed
 -- missing construction of realizability topos
-constant RT : PCA → topos
+undefined_const RT : (PCA → topos) :=
+{description := "realizability topos",
+ doi := ["https://ncatlab.org/nlab/show/realizability+topos"]}

--- a/instructions.markdown
+++ b/instructions.markdown
@@ -18,7 +18,7 @@ Once you are ready to contribute, assuming you took care of the prerequisites (s
 
 1. fork the [`formalabstracts` repository](https://github.com/formalabstracts/formalabstracts)
 2. clone it to your local computer
-3. run `leanpgh configure` inside the `formalbastracts` folder
+3. run `leanpkg configure` inside the `formalbastracts` folder
 
 ## Contributing
 

--- a/meta_data.lean
+++ b/meta_data.lean
@@ -1,6 +1,3 @@
-import data.stream
-
-
 /- Each fabstract contains a list of results. The following type lists the
    various kinds of results. You may read the values as follows:
 
@@ -116,8 +113,5 @@ do nm ← ident,
    tk ":=",
    struct ← lean.parser.pexpr,
    add_undefined_const nm tp struct
-
-/-unproved_theorem my_new_theorem : ∀ n : ℕ, n > 0 :=
-{description := "hi", doi := ["bye"]}-/
 
 end user_commands

--- a/meta_data.lean
+++ b/meta_data.lean
@@ -1,3 +1,6 @@
+import data.stream
+
+
 /- Each fabstract contains a list of results. The following type lists the
    various kinds of results. You may read the values as follows:
 
@@ -42,11 +45,79 @@ inductive {u} result : Type (u+1)
 /-
 TODO: This definition forces all the results in a particular fabstract
 to lie in the same universe.
+
+Each formal abstract contains an instance of the meta_data structure,
+describing the contents.
 -/
--- Each formal abstract contains an instance of the meta_data structure,
--- describing the contents.
 structure {u} meta_data : Type (u+1) :=
     (description : string) -- short description of the contents
     (authors : list string) -- list of authors
     (doi : list string) -- references to the original article
     (results : list (result.{u})) -- the list of main results
+
+/-
+Users will want to assume that a certain objects exist,
+without constructing them. These objects could be types (e.g. the
+real numbers) or inhabitants of types (e.g. pi : ℝ). When we add
+constants like this, we tag them with informal descriptions 
+(of what the structure is, or how the construction goes) 
+and references to the literature.
+-/
+structure undefined_const_meta_data :=
+    (description : string)
+    (doi : list string)
+
+/-
+Similarly, we may want to assume that certain theorems hold without proof.
+We declare these structures separately for now, assuming that later on
+we may want to collect different kinds of metadata.
+-/
+structure unproved_theorem_meta_data :=
+    (description : string)
+    (doi : list string)
+
+
+section user_commands
+open lean.parser tactic interactive
+
+meta def add_unproved_thm (nm : name) (tp data : expr ff) : command :=
+do eltp ← to_expr tp,
+   eldt ← to_expr ``(%%data : unproved_theorem_meta_data),
+   let axm := declaration.ax nm [] eltp,
+   add_decl axm,
+   let meta_data_name := nm.append `_meta_data,
+   add_decl $ mk_definition meta_data_name []
+                  `(unproved_theorem_meta_data) eldt
+
+meta def add_undefined_const (nm : name) (tp data : expr ff) : command :=
+do eltp ← to_expr tp,
+   eldt ← to_expr ``(%%data : undefined_const_meta_data),
+   let axm := declaration.cnst nm [] eltp tt,
+   add_decl axm,
+   let meta_data_name := nm.append `_meta_data,
+   add_decl $ mk_definition meta_data_name []
+                  `(undefined_const_meta_data) eldt
+
+
+@[user_command]
+meta def unproved_thm_cmd (meta_info : decl_meta_info) (_ : parse $ tk "unproved_theorem") : lean.parser unit := 
+do nm ← ident,
+   tk ":",
+   tp ← lean.parser.pexpr,
+   tk ":=",
+   struct ← lean.parser.pexpr,
+   add_unproved_thm nm tp struct
+
+@[user_command]
+meta def undefined_const_cmd (meta_info : decl_meta_info) (_ : parse $ tk "undefined_const") : lean.parser unit := 
+do nm ← ident,
+   tk ":",
+   tp ← lean.parser.pexpr,
+   tk ":=",
+   struct ← lean.parser.pexpr,
+   add_undefined_const nm tp struct
+
+/-unproved_theorem my_new_theorem : ∀ n : ℕ, n > 0 :=
+{description := "hi", doi := ["bye"]}-/
+
+end user_commands


### PR DESCRIPTION
Rather than use `constant` and `axiom` to introduce undefined terms and unproved theorems, we should tag them with meta data. This introduces new commands `undefined_const` and `unproved_theorem` with similar syntax to `def` and `theorem`. These commands add constants or axioms with the given name and type, and store the attached meta data in a new declaration.

Example:
```lean
undefined_const PCA : Type :=
{description := "partial combinatory algebra",
 doi := ["https://ncatlab.org/nlab/show/partial+combinatory+algebra"]}
```
is equivalent to writing
```lean
constant PCA : Type

def PCA._meta_data : undefined_const_meta_data := 
{description := "partial combinatory algebra",
 doi := ["https://ncatlab.org/nlab/show/partial+combinatory+algebra"]}
```
There are some remaining to-dos. The binding strength isn't quite right, so parens are needed sometimes where they shouldn't be necessary. We can also write a command similar to `#print axioms` that will display the meta data in a nice way.