### PR TITLE
Birkhoff's ergodic theorem

### DIFF
--- a/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
+++ b/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
@@ -1,0 +1,54 @@
+import folklore.measure_theory 
+noncomputable theory
+open set real_axiom.extended_real
+
+namespace Birkhoff_G_ErgodicTheorem
+
+variables {X : Type} (σ : set (set X)) [sigma_algebra σ] (μ : set X → ℝ∞) [hms : measure_space σ μ]
+
+def measure_preserving (T : X → X) := ∀ s ∈ σ, μ (image T s) = μ s
+
+def {u} function.pow {α : Type u} (f : α → α) : ℕ → (α → α)
+| 0 := id
+| (n+1) := f ∘ (function.pow n)
+
+def {u} nth_preimage {α : Type u} (f : α → α) : ℕ → (set α → set α)
+| 0 := id
+| (n+1) := λ s, {a | f a ∈ nth_preimage n s}
+
+variable (T : X → X)
+
+def ergodic [finite_measure_space σ μ] := ∀ E ∈ σ, nth_preimage T 1 E = E → μ E = 0 ∨ μ E = of_real (univ_measure σ μ)
+
+variables (f : X → ℝ) [lebesgue_integrable σ μ f]
+
+include hms
+def time_average_partial (x : X) : ℕ → ℝ :=
+(λ n, (1/n)*((((list.iota n).map (λ k, f (function.pow T k x)))).foldr (+) 0))
+
+def time_average_exists (x : X) : Prop :=
+nat_limit_at_infinity_exists (time_average_partial σ μ T f x)
+
+def time_average (x : X) : ℝ := 
+nat_limit_at_infinity (time_average_partial σ μ T f x)
+omit hms
+
+def space_average [finite_measure_space σ μ] [lebesgue_integrable σ μ f] := (1/univ_measure σ μ)*lebesgue_integral σ μ f
+
+
+unfinished Birkhoffs_ergodic_theorem :
+    ∀ {X} {σ : set (set X)} {μ} [sigma_algebra σ] [finite_measure_space σ μ],
+    ∀ (f : X → ℝ) [lebesgue_integrable σ μ f], 
+    ∀ {T : X → X} (t_mp : measure_preserving σ μ T) (t_erg : ergodic σ μ T),
+         almost_everywhere σ μ (λ x : X, time_average_exists σ μ T f x ∧ time_average σ μ T f x = space_average σ μ f) :=
+{description := "Birkhoff's ergodic theorem."}
+
+def fabstract : meta_data :=
+{description := "Birkhoff's ergodic theorem states that, under appropriate conditions, the space average of an integrable function f is equal to the time average of f wrt a measure preserting transformation T. This result was proved in a slightly different form by Birkhoff (1931), and stated and proved in this form by many others, including Halmos (1960) and Furstenberg (1981).",
+authors := [{name := "George Birkhoff"}],
+primary := cite.DOI "10.1073/pnas.17.2.656",
+results := [result.Proof @Birkhoffs_ergodic_theorem]
+}
+
+
+end  Birkhoff_G_ErgodicTheorem

--- a/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
+++ b/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
@@ -45,8 +45,8 @@ unfinished Birkhoffs_ergodic_theorem :
 
 def fabstract : meta_data :=
 {description := "Birkhoff's ergodic theorem states that, under appropriate conditions, the space average of an integrable function f is equal to the time average of f wrt a measure preserting transformation T. This result was proved in a slightly different form by Birkhoff (1931), and stated and proved in this form by many others, including Halmos (1960) and Furstenberg (1981).",
-authors := [{name := "George Birkhoff"}],
-primary := cite.DOI "10.1073/pnas.17.2.656",
+authors := [{name := "Harry Furstenberg"}],
+primary := cite.DOI "10.1515/9781400855162.59",
 results := [result.Proof @Birkhoffs_ergodic_theorem]
 }
 

--- a/folklore/analysis.lean
+++ b/folklore/analysis.lean
@@ -1,0 +1,32 @@
+import .real_axiom
+open classical real_axiom
+local attribute [instance] prop_decidable
+noncomputable theory
+
+-- This will all be made obsolete once Lean 3 has a proper analysis library.
+-- In Lean 2, limits were defined much more generally using filters.
+
+def real_approaches_at (f : ℝ → ℝ) (a b : ℝ) : Prop :=
+∀ ε > 0, ∃ δ, ∀ x, 0 < abs (x - δ) → abs (f x - a) < ε
+
+def real_approaches_at_infinity (f : ℝ → ℝ) (b : ℝ) : Prop :=
+∀ ε > 0, ∃ N, ∀ x > N, abs (f x - b) < ε
+
+def nat_approaches_at_infinity (f : ℕ → ℝ) (b : ℝ) : Prop :=
+∀ ε > 0, ∃ N, ∀ x > N, abs (f x - b) < ε
+
+
+def real_limit_at_infinity_exists (f : ℝ → ℝ) : Prop :=
+∃ b, real_approaches_at_infinity f b
+
+def real_limit_at_infinity (f : ℝ → ℝ) : ℝ :=
+if h : real_limit_at_infinity_exists f then some h
+else 0
+
+
+def nat_limit_at_infinity_exists (f : ℕ → ℝ) : Prop :=
+∃ b, nat_approaches_at_infinity f b
+
+def nat_limit_at_infinity (f : ℕ → ℝ) : ℝ :=
+if h : nat_limit_at_infinity_exists f then some h
+else 0

--- a/folklore/measure_theory.lean
+++ b/folklore/measure_theory.lean
@@ -1,0 +1,108 @@
+import .real_axiom .analysis
+open set classical real_axiom real_axiom.extended_real
+local attribute [instance] prop_decidable
+noncomputable theory
+
+def countable_union {X : Type} (f : ℕ → set X) : set X := 
+{x | ∃ n, x ∈ f n}
+
+variables {X : Type} (σ : set (set X))
+class sigma_algebra :=
+(univ_mem : univ ∈ σ)
+(closed_under_comp : ∀ s, s ∈ σ → univ \ s ∈ σ)
+(closed_under_countable_union : ∀ f : ℕ → set X, (∀ n, f n ∈ σ) → countable_union f ∈ σ)
+
+variable [sigma_algebra σ]
+
+-- alternatively, we could define μ using subtypes, as a function {s : set X // s ∈ σ} → ℝ∞.
+class measure_space (μ : (set X) → ℝ∞) :=
+(measure_nonneg : ∀ s ∈ σ, μ s ≥ 0)
+(measure_empty : μ ∅ = 0)
+(measure_union : ∀ (f : ℕ → set X), (∀ n, f n ∈ σ) → (∀ m n, m ≠ n → f m ∩ f n = ∅) →
+   μ (countable_union f) = extended_real.countable_sum (μ ∘ f))
+
+class finite_measure_space (μ : (set X) → ℝ∞) extends measure_space σ μ :=
+(measure_univ_finite : ∃ b : ℝ, μ univ = of_real b)
+
+def univ_measure (μ : (set X) → ℝ∞) [finite_measure_space σ μ] : ℝ := 
+some (@finite_measure_space.measure_univ_finite X σ (by apply_instance) μ (by apply_instance))
+
+def lebesgue_measurable (f : X → ℝ) :=
+∀ t : ℝ, {x | f x > t} ∈ σ
+
+-- note that we assume μ is a total function here. Theorems involving μ should assume the arguments are in σ.
+variable μ : (set X) → ℝ∞
+
+section
+variable [measure_space σ μ]
+
+-- this assumes s ∈ σ
+def indicator_measure (s : set X) : ℝ∞ := μ s
+
+def indicator_function (s : set X) (x : X) : ℝ := if x ∈ s then 1 else 0
+
+def is_simple_function (ls : list (ℝ × (set X))) := ∀ p : ℝ × (set X), p ∈ ls → p.1 ≥ 0 ∧ p.2 ∈ σ
+
+def simple_function (ls : list (ℝ × (set X))) (x : X) : ℝ := 
+(ls.map (λ p : ℝ × (set X), p.1 * indicator_function p.2 x)).foldr (+) 0
+
+-- must use 0*∞ = 0
+-- this assumes is_simple_function ls
+def simple_function_integral (ls : list (ℝ × (set X))) : ℝ∞ :=
+(ls.map (λ p : ℝ × (set X), of_real p.1 * indicator_measure μ p.2)).foldr (+) 0
+
+-- this will be better looking once we have better parsing for unfinished
+unfinished simple_function_integral_well_defined :
+ ∀ {X μ σ} [sigma_algebra σ] [measure_space σ μ] (ls1 : list (ℝ × set X)) (ls2 : list (ℝ × set X)),  
+    (∀ p : ℝ × (set X), p ∈ ls1 → p.1 ≥ 0 ∧ p.2 ∈ σ) → (∀ p : ℝ × (set X), p ∈ ls2 → p.1 ≥ 0 ∧ p.2 ∈ σ) → 
+      (lebesgue_measurable σ (simple_function ls1)) → (lebesgue_measurable σ (simple_function ls2)) → 
+        (simple_function ls1 = simple_function ls2) → (simple_function_integral μ ls1 = simple_function_integral μ ls2) :=
+{ description := "the integral of a simple function does not depend on the representation of that function" }
+
+-- assumes for (h : ∀ x, f x ≥ 0)
+-- wiki defines this with f : X → ℝ∞ . why?
+def nonneg_function_integral (f : X → ℝ) : ℝ∞ :=
+extended_real.sup 
+  (image (simple_function_integral μ) 
+   {ls : list (ℝ × (set X)) | is_simple_function σ ls ∧ ∀ x, 0 ≤ simple_function ls x ∧  (simple_function ls x) ≤ f x})
+
+-- this shorter version should work when unfinished is fixed
+/-unfinished simple_function_integral_eq_nonneg_function_integral :
+ ∀ {X μ σ} [sigma_algebra σ] [measure_space σ μ] (ls : list (ℝ × set X)),
+    (∀ p : ℝ × (set X), p ∈ ls → p.1 ≥ 0 ∧ p.2 ∈ σ) → (lebesgue_measurable σ (simple_function ls)) →
+     simple_function_integral μ ls = nonneg_function_integral σ μ (simple_function ls) :=
+{ description := "the simple and nonnegative integrals match" }-/
+unfinished simple_function_integral_eq_nonneg_function_integral :
+ ∀ {X μ σ} [sigma_algebra σ] [measure_space σ μ] (ls : list (ℝ × set X)),
+    (∀ p : ℝ × (set X), p ∈ ls → p.1 ≥ 0 ∧ p.2 ∈ σ) → (lebesgue_measurable σ (simple_function ls)) →
+     simple_function_integral μ ls = @nonneg_function_integral _ σ _ μ (by apply_instance) (simple_function ls) :=
+{ description := "the simple and nonnegative integrals match" }
+
+def pos_part (f : X → ℝ) (x : X) : ℝ := if f x > 0 then f x else 0
+def neg_part (f : X → ℝ) (x : X) : ℝ := if f x < 0 then -(f x) else 0
+
+theorem pos_part_nonneg (f : X → ℝ) (x : X) : pos_part f x ≥ 0 :=
+begin cases (em (f x > 0)), all_goals {unfold pos_part, simp *}, {apply le_of_lt, assumption}, apply le_refl end
+
+theorem neg_part_nonneg (f : X → ℝ) (x : X) : neg_part f x ≥ 0 :=
+begin cases (em (f x < 0)), all_goals {unfold neg_part, simp *}, {apply le_of_lt, apply neg_pos_of_neg, assumption}, apply le_refl end
+
+unfinished pos_part_plus_neg_part : ∀ {X} (f : X → ℝ) (x : X), abs (f x) = pos_part f x + neg_part f x :=
+{ description := "abs f decomposes into the sum of pos and neg parts" }
+
+-- assumes nonneg_function_integral (pos_part f) < ∞ or nonneg_function_integral (neg_part f) < ∞
+
+def signed_integral_exists_condition (f : X → ℝ) := nonneg_function_integral σ μ (pos_part f) < inf ∨ nonneg_function_integral σ μ (neg_part f) < inf
+
+-- assumes signed_integral_exists_condition f
+def signed_function_integral (f : X → ℝ) : ℝ∞ :=
+nonneg_function_integral σ μ (pos_part f) + nonneg_function_integral σ μ (neg_part f)
+
+class lebesgue_integrable (f : X → ℝ) :=
+(r : ℝ) (f_integrable : signed_integral_exists_condition σ μ f) (integral_value : signed_function_integral σ μ f = of_real r)
+
+def lebesgue_integral (f : X → ℝ) [lebesgue_integrable σ μ f] : ℝ := @lebesgue_integrable.r X σ (by apply_instance) μ (by apply_instance) f (by apply_instance)
+
+def almost_everywhere (P : X → Prop) := {x | ¬ P x} ∈ σ ∧ μ {x | ¬ P x} = 0
+
+end

--- a/folklore/measure_theory.lean
+++ b/folklore/measure_theory.lean
@@ -15,6 +15,7 @@ class sigma_algebra :=
 variable [sigma_algebra σ]
 
 -- alternatively, we could define μ using subtypes, as a function {s : set X // s ∈ σ} → ℝ∞.
+-- this complicates some things and simplifies others.
 class measure_space (μ : (set X) → ℝ∞) :=
 (measure_nonneg : ∀ s ∈ σ, μ s ≥ 0)
 (measure_empty : μ ∅ = 0)
@@ -46,6 +47,10 @@ def is_simple_function (ls : list (ℝ × (set X))) := ∀ p : ℝ × (set X), p
 def simple_function (ls : list (ℝ × (set X))) (x : X) : ℝ := 
 (ls.map (λ p : ℝ × (set X), p.1 * indicator_function p.2 x)).foldr (+) 0
 
+unfinished simple_function_pos : ∀ {X} (σ : set (set X)) (μ : set X → ℝ∞) [sigma_algebra σ] [measure_space σ μ],
+  ∀ (ls : list (ℝ × (set X))), (∀ p : ℝ × (set X), p ∈ ls → p.1 ≥ 0 ∧ p.2 ∈ σ) → ∀ x, simple_function ls x ≥ 0 :=
+{ description := "simple functions are nonnegative" }
+
 -- must use 0*∞ = 0
 -- this assumes is_simple_function ls
 def simple_function_integral (ls : list (ℝ × (set X))) : ℝ∞ :=
@@ -59,8 +64,7 @@ unfinished simple_function_integral_well_defined :
         (simple_function ls1 = simple_function ls2) → (simple_function_integral μ ls1 = simple_function_integral μ ls2) :=
 { description := "the integral of a simple function does not depend on the representation of that function" }
 
--- assumes for (h : ∀ x, f x ≥ 0)
--- wiki defines this with f : X → ℝ∞ . why?
+-- assumes (h : ∀ x, f x ≥ 0)
 def nonneg_function_integral (f : X → ℝ) : ℝ∞ :=
 extended_real.sup 
   (image (simple_function_integral μ) 
@@ -90,18 +94,20 @@ begin cases (em (f x < 0)), all_goals {unfold neg_part, simp *}, {apply le_of_lt
 unfinished pos_part_plus_neg_part : ∀ {X} (f : X → ℝ) (x : X), abs (f x) = pos_part f x + neg_part f x :=
 { description := "abs f decomposes into the sum of pos and neg parts" }
 
--- assumes nonneg_function_integral (pos_part f) < ∞ or nonneg_function_integral (neg_part f) < ∞
-
-def signed_integral_exists_condition (f : X → ℝ) := nonneg_function_integral σ μ (pos_part f) < inf ∨ nonneg_function_integral σ μ (neg_part f) < inf
+def signed_integral_exists_condition (f : X → ℝ) := 
+nonneg_function_integral σ μ (pos_part f) < inf ∨ nonneg_function_integral σ μ (neg_part f) < inf
 
 -- assumes signed_integral_exists_condition f
 def signed_function_integral (f : X → ℝ) : ℝ∞ :=
 nonneg_function_integral σ μ (pos_part f) + nonneg_function_integral σ μ (neg_part f)
 
 class lebesgue_integrable (f : X → ℝ) :=
-(r : ℝ) (f_integrable : signed_integral_exists_condition σ μ f) (integral_value : signed_function_integral σ μ f = of_real r)
+(r : ℝ) 
+(f_integrable : signed_integral_exists_condition σ μ f) 
+(integral_value : signed_function_integral σ μ f = of_real r)
 
-def lebesgue_integral (f : X → ℝ) [lebesgue_integrable σ μ f] : ℝ := @lebesgue_integrable.r X σ (by apply_instance) μ (by apply_instance) f (by apply_instance)
+def lebesgue_integral (f : X → ℝ) [lebesgue_integrable σ μ f] : ℝ :=
+ @lebesgue_integrable.r X σ (by apply_instance) μ (by apply_instance) f (by apply_instance)
 
 def almost_everywhere (P : X → Prop) := {x | ¬ P x} ∈ σ ∧ μ {x | ¬ P x} = 0
 

--- a/folklore/real_axiom.lean
+++ b/folklore/real_axiom.lean
@@ -140,6 +140,9 @@ instance : has_one ℝ∞ := ⟨extended_real.of_real 1⟩
 
 attribute [instance] ext_reals_has_add ext_reals_has_sub ext_reals_has_mul ext_reals_has_div ext_reals_order
 
+unfinished ext_reals_mul_spec : extended_real.inf * 0 = 0 :=
+{ description := "we specify that ∞ * 0 = 0" }
+
 def extended_real.sup (s : set extended_real) : extended_real :=
 if extended_real.inf ∈ s then extended_real.inf
 else let non_neg_inf := {r | ∃ r' ∈ s, r' = extended_real.of_real r} in


### PR DESCRIPTION
I thought I'd try this fabstract as an experiment, because it raises some interesting points for discussion.

1. The theorem formalized here is not stated exactly as Birkhoff stated it in 1931. As I understand it, the proof he gives in that paper more or less transfers over to this formulation, but the statements are not exactly "equivalent." The version I've formalized is what is generally referred to as "Birkhoff's ergodic theorem," the one that appears in textbooks, etc.
How true do we intend to stay to the intent of the author(s)? Especially with historical papers, a direct translation of the statement can be surprisingly hard to reconcile with modern notation, definitions, conventions, etc. I think we're facing big problems with library management already. Adding a historical dimension will complicate that even more. On the other hand, is it fair to Birkhoff to "reinterpret" his paper like this? Should someone else be cited in addition/instead?

2. I defined various things that will eventually appear, in a more general form, in the Lean mathematics library. Because my definitions will (I assume) be replaced eventually, I put in the bare minimum effort. At some point we'll want to base this project on top of that Lean library and replace things in folklore, but is there a cutoff? Are my fake extended real numbers "good enough" for now? Should I bother to generalize the limit definitions? I think these are things to think about for now (or whenever we really start a library) and later, since "how general should I make my definitions" is a question that will never go away.
Note: we have a math library in development (https://github.com/leanprover/library_dev), but I don't think it's a good idea to import that project yet.

3. What do we do with partial functions/definitions that depend on propositions? This question appears in a few places in this PR. I define a measure space using `(μ : (set X) → ℝ∞)`, instead of defining μ only on the sigma algebra. This means that theorem statements have to include the hypotheses that μ is only applied to elements of the algebra (see `simple_function_integral_well_defined`). But, without any proofs, this makes it really easy to forget hypotheses. I'm not unhappy with this approach, it just takes careful reviewing.
The alternative is to include hypotheses in the definitions (ie `nonneg_function_integral` could take a proof that `f` is nonnegative as an argument). But we're not writing real proofs. It would be a huge pain if, every time we had to use `nonneg_function_integral`, we had to factor the nonnegativity proof out into a separate `unfinished`. So we'd at least need a way to "inline" `unfinished`, like `sorry`. This would get messy.