### PR TITLE
upgrade to changes in Lean library organization

### DIFF
--- a/fabstract/Hales_T_et_al_Kepler_conj/fabstract.lean
+++ b/fabstract/Hales_T_et_al_Kepler_conj/fabstract.lean
@@ -50,7 +50,8 @@ def packing {n : ℕ} (V : set (vector ℝ n)) :=
 def open_ball {n : ℕ} (x0 : vector ℝ n) (r : ℝ) : (set (vector ℝ n)) :=
 { u | euclid_metric x0 u < r}
 
-def origin₃ : vector ℝ 3 := [0,0,0]
+-- this is a temporary workaround (https://github.com/leanprover/lean/commit/16e7976b1a7e2ce9624ad2df363c007b70d70096)
+def origin₃ : vector ℝ 3 := 0::0::0::nil--[0,0,0]
 
 -- TODO: provide the theorem number from the paper
 unfinished Kepler_conjecture :

--- a/folklore/real_axiom.lean
+++ b/folklore/real_axiom.lean
@@ -8,8 +8,7 @@ construction.
 T.Hales, July 15, 2017
 -/
 
-import meta_data
-import data.list data.vector
+import meta_data data.list
 
 noncomputable theory
 

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -3,4 +3,4 @@ name = "formalabstracts"
 version = "0.1"
 
 [dependencies]
-stdlib = {git = "https://github.com/leanprover/stdlib", rev = "b8ea20f7b0278ae5f8644641a6f3108f8baf51af"}
+stdlib = {git = "https://github.com/leanprover/stdlib", rev = "8f6549653e85b61b23d84a464299b79ce4308ee6"}

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -3,3 +3,4 @@ name = "formalabstracts"
 version = "0.1"
 
 [dependencies]
+stdlib = {git = "https://github.com/leanprover/stdlib", rev = "b8ea20f7b0278ae5f8644641a6f3108f8baf51af"}


### PR DESCRIPTION
Some of the Lean library was moved out of the main repository into `stdlib`, so this project now needs to depend on that library.

Note: you'll need a version of Lean from the past day or two in order to build this. You may have to clean the `.olean` files in `formalabstracts` to get things to build.