### PR TITLE
Meta data refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*~
 *.olean
 /_target
 /leanpkg.path

--- a/fabstract/Bauer_A_InjBaireNat/categories.lean
+++ b/fabstract/Bauer_A_InjBaireNat/categories.lean
@@ -25,8 +25,7 @@ structure terminal_object {C : category} :=
 
 -- exponentials in a category
 unfinished missing_exponential_structure : Type :=
-{ description := "remaining properties of exponentials",
-  references := []
+{ description := "remaining properties of exponentials"
 }
 
 structure exponential {C : category} (A B : C.obj) :=

--- a/fabstract/Bauer_A_InjBaireNat/fabstract.lean
+++ b/fabstract/Bauer_A_InjBaireNat/fabstract.lean
@@ -1,18 +1,35 @@
 import meta_data
        .toposes
        .realizability
+       ...smart_cmd_test.scholar_info
 
 namespace Bauer_A_InjBaireNat
 
 noncomputable theory
 
+def Bauer_A_InjBaireNat_paper : cite :=
+cite.Document
+ { title     := "An injection from the Baire space to natural numbers",
+   authors   := [{name := "Bauer, Andrej"}],
+   doi       := "10.1017/S0960129513000406",
+   source    := "Mathematical Structures in Computer Science",
+   year      := ↑2015,
+   reference := "Mathematical Structures in Computer Science 25:7, 1484--1489 (2015)" }
+
 -- we construct a partial combinatory algebra based on
 -- infinite-time Turing machines
 unfinished J : PCA :=
 { description := "a partial-combinatory algebra constructured from infinite time turing machine",
-  references := [cite.Item cite.Ibidem "Section 3",
-                 cite.DOI "10.1023/A:1021180801870",
-                 cite.Arxiv "math/9808093"] }
+  sources     := [cite.Item Bauer_A_InjBaireNat_paper "Section 3",
+                  cite.Document 
+                  { title     := "Infinite time Turing machines",
+                    authors   := [{name := "Hamkins, Joel David"}],
+                    doi       := "10.1023/A:1021180801870",
+                    source    := "Minds and Machines",
+                    year      := ↑2002,
+                    arxiv     := "math/9808093",
+                    url       := "", 
+                    reference := "Minds and Machines 12:4, 521--539 (2002)" } ] }
 
 definition RT_J := RT J
 
@@ -22,23 +39,21 @@ definition Baire := (RT_J.exponent N N).underlying_object
 
 unfinished Baire_to_N : RT_J.underlying_category.hom Baire N :=
 { description := "A morphism from N^N to N",
-  references := [cite.Item cite.Ibidem "Section 4"] }
+  sources     := [cite.Item Bauer_A_InjBaireNat_paper "Section 4"] }
 
 unfinished Baire_to_N_is_mono : monomorphism Baire_to_N :=
 { description := "The morphism Baire_to_N from N^Nto N is mono",
-  references := [cite.Item cite.Ibidem "Section 4"] }
+  sources     := [cite.Item Bauer_A_InjBaireNat_paper "Section 4"] }
 
-def fabstract : meta_data := {
-  description := "We construct a realizability topos in which the reals are embedded in the natural numbers. The topos is based on infinite-time Turing machines of Joel Hamkins.",
-  authors := [{name := "Andrej Bauer", homepage := "http://www.andrej.com"}],
-  primary := cite.DOI "10.1017/S0960129513000406",
-  secondary := [
-    cite.URL "http://math.andrej.com/2011/06/15/constructive-gem-an-injection-from-baire-space-to-natural-numbers/", -- blog
-    cite.URL "https://vimeo.com/30368682" -- video of a talk about the paper
+def fabstract : fabstract := 
+{ description  := "We construct a realizability topos in which the reals are embedded in the natural numbers. The topos is based on infinite-time Turing machines of Joel Hamkins.",
+  contributors := [{name := "Andrej Bauer", homepage := "http://www.andrej.com"}],
+  sources      := [Bauer_A_InjBaireNat_paper,
+                   cite.Website "http://math.andrej.com/2011/06/15/constructive-gem-an-injection-from-baire-space-to-natural-numbers/", -- blog
+                   cite.Website "https://vimeo.com/30368682" -- video of a talk about the paper
   ],
-  results := [result.Construction J,
-              result.Construction Baire_to_N,
-              result.Proof Baire_to_N_is_mono]
-}
+  results      := [result.Construction J,
+                   result.Construction Baire_to_N,
+                   result.Proof Baire_to_N_is_mono] }
 
 end Bauer_A_InjBaireNat

--- a/fabstract/Bauer_A_InjBaireNat/fabstract.lean
+++ b/fabstract/Bauer_A_InjBaireNat/fabstract.lean
@@ -1,7 +1,7 @@
 import meta_data
        .toposes
        .realizability
-       ...smart_cmd_test.scholar_info
+
 
 namespace Bauer_A_InjBaireNat
 

--- a/fabstract/Bauer_A_InjBaireNat/realizability.lean
+++ b/fabstract/Bauer_A_InjBaireNat/realizability.lean
@@ -12,11 +12,12 @@ run_cmd tactic.skip -- temporary fix
 unfinished PCA : Type :=
   {
     description := "partial combinatory algebra",
-    references := [cite.URL "https://ncatlab.org/nlab/show/partial+combinatory+algebra"]
+    sources     := [cite.Website "https://ncatlab.org/nlab/show/partial+combinatory+algebra"]
   }
 
-unfinished RT : PCA → topos :=
+
+unfinished RT : (PCA → topos) :=
   {
     description := "realizability topos",
-    references := [cite.URL "https://ncatlab.org/nlab/show/realizability+topos"]
+    sources     := [cite.Website "https://ncatlab.org/nlab/show/realizability+topos"]
   }

--- a/fabstract/Bauer_A_InjBaireNat/toposes.lean
+++ b/fabstract/Bauer_A_InjBaireNat/toposes.lean
@@ -7,7 +7,7 @@ run_cmd tactic.skip -- temporary fix
 
 unfinished nno_structure : category → Type :=
   { description := "natural numbers object in a category",
-    references := [cite.URL "https://ncatlab.org/nlab/show/natural+numbers+object"] }
+    sources     := [cite.Website "https://ncatlab.org/nlab/show/natural+numbers+object"] }
 
 structure natural_numbers (C : category) :=
     (underlying_object : C.obj)
@@ -15,7 +15,7 @@ structure natural_numbers (C : category) :=
 
 unfinished missing_topos_structure : Type :=
   { description := "the rest of the structure of an elementary topos",
-    references := [cite.URL "https://ncatlab.org/nlab/show/topos"] }
+    sources     := [cite.Website "https://ncatlab.org/nlab/show/topos"] }
 
 structure topos :=
     (underlying_category : category)

--- a/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
+++ b/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
@@ -6,6 +6,7 @@ namespace Birkhoff_G_ErgodicTheorem
 
 variables {X : Type} (σ : set (set X)) [sigma_algebra σ] (μ : set X → ℝ∞) [hms : measure_space σ μ]
 
+@[meta_data {description := "A transformation is measure preserving if the measure of the image of every set is equal to the measure of the set."}]
 def measure_preserving (T : X → X) := ∀ s ∈ σ, μ (image T s) = μ s
 
 def {u} function.pow {α : Type u} (f : α → α) : ℕ → (α → α)
@@ -18,6 +19,7 @@ def {u} nth_preimage {α : Type u} (f : α → α) : ℕ → (set α → set α)
 
 variable (T : X → X)
 
+@[meta_data {description := "A transformation is ergodic if the only sets that map to themselves are null or conull."}]
 def ergodic [finite_measure_space σ μ] := ∀ E ∈ σ, nth_preimage T 1 E = E → μ E = 0 ∨ μ E = of_real (univ_measure σ μ)
 
 variables (f : X → ℝ) [lebesgue_integrable σ μ f]
@@ -29,10 +31,12 @@ def time_average_partial (x : X) : ℕ → ℝ :=
 def time_average_exists (x : X) : Prop :=
 nat_limit_at_infinity_exists (time_average_partial σ μ T f x)
 
+@[meta_data {description := "The time average of f under T at x is the limit of (1/n)*Σ{k=1...n} f(T^k(x)) as n→∞"}]
 def time_average (x : X) : ℝ := 
 nat_limit_at_infinity (time_average_partial σ μ T f x)
 omit hms
 
+@[meta_data {description := "The space average of f is (1/μ(univ))*∫f dμ"}]
 def space_average [finite_measure_space σ μ] [lebesgue_integrable σ μ f] := (1/univ_measure σ μ)*lebesgue_integral σ μ f
 
 

--- a/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
+++ b/fabstract/Birkhoff_G_ErgodicTheorem/fabstract.lean
@@ -43,12 +43,17 @@ unfinished Birkhoffs_ergodic_theorem :
          almost_everywhere σ μ (λ x : X, time_average_exists σ μ T f x ∧ time_average σ μ T f x = space_average σ μ f) :=
 {description := "Birkhoff's ergodic theorem."}
 
-def fabstract : meta_data :=
-{description := "Birkhoff's ergodic theorem states that, under appropriate conditions, the space average of an integrable function f is equal to the time average of f wrt a measure preserting transformation T. This result was proved in a slightly different form by Birkhoff (1931), and stated and proved in this form by many others, including Halmos (1960) and Furstenberg (1981).",
-authors := [{name := "Harry Furstenberg"}],
-primary := cite.DOI "10.1515/9781400855162.59",
-results := [result.Proof @Birkhoffs_ergodic_theorem]
-}
+def furstenberg_source : document :=
+{ authors := [{name := "Harry Furstenberg"}],
+  title   := "Recurrence in Ergodic Theory",
+  year    := ↑1981,
+  doi     := "10.1515/9781400855162.59"}
+
+def fabstract : fabstract := 
+{ description  := "Birkhoff's ergodic theorem states that, under appropriate conditions, the space average of an integrable function f is equal to the time average of f wrt a measure preserting transformation T. This result was proved in a slightly different form by Birkhoff (1931), and stated and proved in this form by many others, including Halmos (1960) and Furstenberg (1981).",
+  contributors := [{name := "Robert Y. Lewis", homepage := "https://andrew.cmu.edu/user/rlewis1"}],
+  sources      := [cite.Document furstenberg_source],
+  results      := [result.Proof @Birkhoffs_ergodic_theorem] }
 
 
 end  Birkhoff_G_ErgodicTheorem

--- a/fabstract/Cook_S_P_NP/fabstract.lean
+++ b/fabstract/Cook_S_P_NP/fabstract.lean
@@ -61,7 +61,7 @@ def SAT : set (list bool) :=
 /- SAT is in NP -/
 unfinished SAT_NP : SAT ∈ NP :=
 { description := "SAT is an NP-problem",
-  references := [cite.Item cite.Ibidem "TODO"] }
+  sources := [cite.Website "TODO(@digama0)"] }
 
 def P_reducible (L₁ L₂ : set (list bool)) : Prop :=
 ∃ f, P_computable f ∧ L₁ = {x | f x ∈ L₂}
@@ -69,13 +69,12 @@ def P_reducible (L₁ L₂ : set (list bool)) : Prop :=
 /- Any problem in NP can be polynomial-time reduced to SAT -/
 unfinished SAT_reducibility : ∀ L ∈ NP, P_reducible L SAT :=
 { description := "Any problem in NP can be polynomial-time reduced to SAT",
-  references := [cite.Item cite.Ibidem "TODO"] }
+  sources := [cite.Website "TODO(@digama0)"] }
 
-def fabstract : meta_data :=
+def fabstract : fabstract :=
 { description := "A conjecture that the complexity classes P and NP are unequal.",
-  authors := [{name := "Stephen A. Cook"}],
-  primary := cite.DOI "10.1145/800157.805047",
-  secondary := [],
+  contributors := [{name := "Mario Carneiro"}],
+  sources :=[cite.Document {title := "The Complexity of theorem-proving procedures", authors := [{name := "Stephen Cook"}], doi := "10.1145/800157.805047"}],
   results := [result.Proof SAT_NP,
               result.Proof SAT_reducibility,
               result.Conjecture (P ≠ NP)] }

--- a/fabstract/Cook_S_P_NP/turing_machines.lean
+++ b/fabstract/Cook_S_P_NP/turing_machines.lean
@@ -62,7 +62,7 @@ begin
     ginduction TM cur head with e,
     { intro e, injection e },
     { cases a with s' a, cases a with v d,
-      simp [next], intro i, injection i, subst h,
+      simp [next], intro i, injection i with h, subst h,
       exact ⟨to_bool_true e⟩ } },
   { intro h, induction h,
     simp [next],

--- a/fabstract/Green_B_and_Tao_T_ArithmeticProgressionsInPrimes/fabstract.lean
+++ b/fabstract/Green_B_and_Tao_T_ArithmeticProgressionsInPrimes/fabstract.lean
@@ -10,13 +10,15 @@ axiom arithmetic_progressions_in_primes :
 
 -- They also prove various stronger statements; this is an important and easy to state consequence.
 
-definition fabstract : meta_data :=
+definition green_tao_doc : document :=
+{ authors := [{name := "Ben Green"}, {name := "Terry Tao"}],
+  title := "The primes contain arbitrarily long arithmetic progressions",
+  doi := "10.4007/annals.2008.167.481" }
+
+def fabstract : fabstract :=
 { description := "The primes contain arbitrarily long arithmetic progressions",
-  authors := [
-    {name := "Ben Green"},
-    {name := "Terry Tao"}
-  ],
-  primary := cite.DOI "10.4007/annals.2008.167.481",
-  results := [result.Proof arithmetic_progressions_in_primes] }
+  contributors := [{name := "Scott Morrison"}],
+  results := [result.Proof arithmetic_progressions_in_primes],
+  sources := [cite.Document green_tao_doc] }
 
 end Green_B_and_Tao_T_ArithmeticProgressionsInPrimes

--- a/fabstract/Hales_T_et_al_Kepler_conj/fabstract.lean
+++ b/fabstract/Hales_T_et_al_Kepler_conj/fabstract.lean
@@ -59,9 +59,14 @@ unfinished Kepler_conjecture :
   (∃ (c : ℝ), ∀ (r : ℝ), (r ≥ 1) ->
   (↑(card(V ∩ open_ball origin₃ r)) ≤ pi* r^3/real_sqrt(18) + c*r^2))) :=
 { description := "Proof of Kepler conjecture",
-  references := [cite.Item cite.Ibidem "Theorem X.Y"] }
+  primary := cite.Item cite.Ibidem "Theorem X.Y" }
 
-def fabstract : meta_data := {
+def Hales_T_et_al_Kepler_conj : fabstract :=
+{
+
+}
+
+/- {
   description := "This article announces the formal proof of the Kepler conjecture on dense sphere packings in a combination of the HOL Light and Isabelle/HOL proof assistants.  It represents the primary result of the now completed Flyspeck project.",
   authors := [
     {name := "Thomas Hales"},
@@ -87,8 +92,10 @@ def fabstract : meta_data := {
     {name := "Ky Vu"},
     {name := "Roland Zumkelle"}
   ],
-  primary := cite.DOI "/10.1017/fmp.2017.1",
+  primary := cite.Document { doi := "/10.1017/fmp.2017.1" },
   results := [result.Proof Kepler_conjecture]
-}
+}-/
+
+#print fabstract
 
 end Hales_T_et_al_Kepler_conj

--- a/fabstract/Hales_T_et_al_Kepler_conj/fabstract.lean
+++ b/fabstract/Hales_T_et_al_Kepler_conj/fabstract.lean
@@ -1,11 +1,12 @@
 import meta_data
        ...folklore.real_axiom
+       data.vector
 
 namespace Hales_T_et_al_Kepler_conj
 
 noncomputable theory
 
-open classical nat set list vector real_axiom
+open classical nat set list real_axiom vector
 
 -- cardinality of finite sets.
 -- Surely this must exist somewhere. But where?
@@ -53,22 +54,8 @@ def open_ball {n : ℕ} (x0 : vector ℝ n) (r : ℝ) : (set (vector ℝ n)) :=
 -- this is a temporary workaround (https://github.com/leanprover/lean/commit/16e7976b1a7e2ce9624ad2df363c007b70d70096)
 def origin₃ : vector ℝ 3 := 0::0::0::nil--[0,0,0]
 
--- TODO: provide the theorem number from the paper
-unfinished Kepler_conjecture :
-(∀ (V : set (vector ℝ 3)), packing V →
-  (∃ (c : ℝ), ∀ (r : ℝ), (r ≥ 1) ->
-  (↑(card(V ∩ open_ball origin₃ r)) ≤ pi* r^3/real_sqrt(18) + c*r^2))) :=
-{ description := "Proof of Kepler conjecture",
-  primary := cite.Item cite.Ibidem "Theorem X.Y" }
-
-def Hales_T_et_al_Kepler_conj : fabstract :=
-{
-
-}
-
-/- {
-  description := "This article announces the formal proof of the Kepler conjecture on dense sphere packings in a combination of the HOL Light and Isabelle/HOL proof assistants.  It represents the primary result of the now completed Flyspeck project.",
-  authors := [
+def hales_et_al_paper : document :=
+{ authors := [
     {name := "Thomas Hales"},
     {name := "Mark Adams"},
     {name := "Gertrud Bauer"},
@@ -92,10 +79,21 @@ def Hales_T_et_al_Kepler_conj : fabstract :=
     {name := "Ky Vu"},
     {name := "Roland Zumkelle"}
   ],
-  primary := cite.Document { doi := "/10.1017/fmp.2017.1" },
-  results := [result.Proof Kepler_conjecture]
-}-/
+ title := "A formal proof of the Kepler Conjecture",
+ doi := "/10.1017/fmp.2017.1" }
 
-#print fabstract
+-- TODO: provide the theorem number from the paper
+unfinished Kepler_conjecture :
+(∀ (V : set (vector ℝ 3)), packing V →
+  (∃ (c : ℝ), ∀ (r : ℝ), (r ≥ 1) ->
+  (↑(card(V ∩ open_ball origin₃ r)) ≤ pi* r^3/real_sqrt(18) + c*r^2))) :=
+{ description := "Proof of Kepler conjecture",
+  sources := [cite.Item (cite.Document hales_et_al_paper) "Theorem X.Y"] }
+
+def Hales_T_et_al_Kepler_conj : fabstract :=
+{ contributors := [{name := "Thomas Hales"}],
+  description := "This article announces the formal proof of the Kepler conjecture on dense sphere packings in a combination of the HOL Light and Isabelle/HOL proof assistants.  It represents the primary result of the now completed Flyspeck project.",
+  results := [result.Proof Kepler_conjecture]
+}
 
 end Hales_T_et_al_Kepler_conj

--- a/fabstract/Roux_C_and_vanDoorn_F_PTSs/fabstract.lean
+++ b/fabstract/Roux_C_and_vanDoorn_F_PTSs/fabstract.lean
@@ -4,6 +4,11 @@ import meta_data
 namespace Roux_C_and_vanDoorn_F_PTSs
 open pure_type_system sum
 
+def paper : document :=
+{ authors := [ {name := "Cody Roux"}, {name := "Floris van Doorn"} ],
+  title := "The structural theory of pure type systems",
+  doi := "10.1007/978-3-319-08918-8_25" }
+
 -- noncomputable theory
 
 /- We investigate combinations and extensions of Pure Type Systems
@@ -20,7 +25,7 @@ definition morphism (P Q : pure_type_system) : Type :=
 unfinished is_weakly_normalizing_domain :
 (Π P Q (f : morphism P Q) (HQ : is_weakly_normalizing Q),  is_weakly_normalizing P) :=
 { description := "It is easy to see that the domain of a morphism is weakly normalizing if the codomain is",
-  references := [cite.Ibidem] }
+  sources := [cite.Document paper] }
 
 /- The direct sum of PTSs -/
 definition direct_sum (P Q : pure_type_system) : pure_type_system :=
@@ -41,7 +46,7 @@ unfinished is_weakly_normalizing_direct_sum  :
   (Π P Q(HP : is_weakly_normalizing P) (HQ : is_weakly_normalizing Q),
     is_weakly_normalizing (direct_sum P Q)) :=
 { description := "It is normalizing if the original ones were",
-  references := [cite.Ibidem] }
+  sources := [cite.Document paper] }
 
 /- The direct sum with quantification over sorts in P added. This can be interpreted as the
   Q-logic of P-terms -/
@@ -64,7 +69,7 @@ unfinished is_weakly_normalizing_forall :
   (Π P Q (HP : is_weakly_normalizing P) (HQ : is_weakly_normalizing Q),
      is_weakly_normalizing (forall_PTS P Q)) :=
 { description := "It is normalizing if the original ones were",
-  references := [cite.Ibidem] }
+  sources := [cite.Document paper] }
 
 /- The predicative polymorphic extension of P -/
 definition poly (P : pure_type_system) : pure_type_system :=
@@ -84,16 +89,12 @@ definition poly (P : pure_type_system) : pure_type_system :=
 unfinished is_weakly_normalizing_poly :
   (Π P (HP : is_weakly_normalizing P), is_weakly_normalizing (poly P)) :=
 { description := "It is normalizing if the original ones was",
-  references := [cite.Ibidem] }
+  sources := [cite.Document paper] }
 
-def fabstract : meta_data := {
+def fabstract : fabstract := {
   description := "We investigate possible extensions of arbitrary given Pure Type Systems with additional sorts and rules which preserve the normalization property.",
-  authors := [
-    {name := "Cody Roux"},
-    {name := "Floris van Doorn"}
-  ],
-  primary := cite.DOI "10.1007/978-3-319-08918-8_25",
-  secondary := [],
+  contributors := [{name := "Floris van Doorn"}],
+  sources := [cite.Document paper],
   results := [result.Proof is_weakly_normalizing_domain,
               result.Proof is_weakly_normalizing_direct_sum,
               result.Proof is_weakly_normalizing_forall,

--- a/fabstract/Roux_C_and_vanDoorn_F_PTSs/pure_type_systems.lean
+++ b/fabstract/Roux_C_and_vanDoorn_F_PTSs/pure_type_systems.lean
@@ -109,7 +109,7 @@ local notation Γ ` ⊢ ` t ` : ` T := typ Γ t T
 -- where "Γ ⊢ t : T" := (typ Γ t T) : UT_scope.
 
 definition is_well_typed (t : term) : Prop :=
-∃(Γ : context) (A : term), Γ ⊢ t : A
+∃(Γ : context) (A : term), typ Γ t A -- Γ ⊢ t : A
 
 parameter (PTS)
 

--- a/fabstract/Wiles_A_and_Taylor_R_FermatLast/fabstract.lean
+++ b/fabstract/Wiles_A_and_Taylor_R_FermatLast/fabstract.lean
@@ -6,14 +6,18 @@ namespace Wiles_A_and_Taylor_R_FermatLast
 axiom fermat_last_theorem :
 ∀ (x y z n : nat), x > 0 → y > 0 → n > 2 → x ^ n + y ^ n ≠ z ^ n
 
-definition fabstract : meta_data :=
-{ description := "A result in number theory conjectured by Pierre de Fermat and proved by Andrew Wiles and Richard Taylor. Colloquially referred to as Fermat's Last Theorem.",
-  authors := [
+def paper : document :=
+{   authors := [
     {name := "Andrew Wiles"},
     {name := "Richard Tylor"}
   ],
-  primary := cite.DOI "10.2307/2118559",
-  secondary := [cite.DOI "10.2307/2118560"],
+  title := "Modular elliptic curves and Fermat's last theorem",
+  doi := "10.2307/2118559"}
+
+definition fabstract : fabstract :=
+{ description := "A result in number theory conjectured by Pierre de Fermat and proved by Andrew Wiles and Richard Taylor. Colloquially referred to as Fermat's Last Theorem.",
+  contributors := [{name := "Adam Kurkiewicz"}],
+  sources := [cite.Document paper],
   results := [result.Proof fermat_last_theorem] }
 
 end Wiles_A_and_Taylor_R_FermatLast

--- a/folklore/real_axiom.lean
+++ b/folklore/real_axiom.lean
@@ -14,7 +14,7 @@ noncomputable theory
 
 namespace real_axiom
 
-open classical nat int list vector
+open classical nat int list
 local attribute [instance] prop_decidable
 universe u
 

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,6 +1,7 @@
 [package]
 name = "formalabstracts"
 version = "0.1"
+lean_version = "master"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover/mathlib.git", rev = "dbc8f869db43dec94f54198cebb7f572d2feac45"}
+mathlib = {git = "https://github.com/leanprover/mathlib.git", rev = "a5f32d27ae141da1db5511d7d9e1992fe5e3c81d"}

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -3,4 +3,4 @@ name = "formalabstracts"
 version = "0.1"
 
 [dependencies]
-stdlib = {git = "https://github.com/leanprover/stdlib", rev = "64b61515b750c85ccb4f9871a6508bdc16e9dddc"}
+mathlib = {git = "https://github.com/leanprover/mathlib.git", rev = "dbc8f869db43dec94f54198cebb7f572d2feac45"}

--- a/meta_data.lean
+++ b/meta_data.lean
@@ -58,7 +58,7 @@ structure document :=
 (url : string := "")
 (source : string := "") -- journal or book title
 (year : option nat := none)
-(reference : string := "")
+(reference : string := "") -- reference formatted with title, volume, issue, pages, year, etc
 
 
 /- There will be many citations everywhere, so it is a good idea

--- a/meta_data.lean
+++ b/meta_data.lean
@@ -132,17 +132,6 @@ meta instance : has_to_format meta_data :=
 structure {u} fabstract extends meta_data :=
 (results : list (result.{u}))
 
-/-
-Users will want to assume that a certain objects exist,
-without constructing them. These objects could be types (e.g. the
-real numbers) or inhabitants of types (e.g. pi : ℝ). When we add
-constants like this, we tag them with informal descriptions
-(of what the structure is, or how the construction goes)
-and references to the literature.
--/
-/-structure unfinished_meta_data :=
-(description : string)
-(references : list cite := [])-/
 
 section user_commands
 open lean.parser tactic interactive
@@ -155,9 +144,6 @@ open lean.parser tactic interactive
     do mdp ← meta_data_tag.get_param n,
        to_expr ``(%%mdp : meta_data) >> return ()) }
 
-@[meta_data_tag {description := "this is meta_data", contributors := [{name := "Robert Lewis"}]}]
-def foo : ℕ := 2
-
 meta def get_meta_data (n : name) : tactic meta_data :=
 do mdp ← meta_data_tag.get_param n,
    to_expr ``(%%mdp : meta_data) >>= eval_expr meta_data
@@ -168,14 +154,10 @@ do mdp ← meta_data_tag.get_param n,
 
 meta def add_unfinished (nm : name) (tp data : expr ff) : command :=
 do eltp ← to_expr tp,
-   --eldt ← to_expr ``(%%data : meta_data),
    let axm := declaration.ax nm [] eltp,
    add_decl axm,
    unfinished_attr.set_param nm () tt,
    meta_data_tag.set_param nm data tt
-/-   let meta_data_name := nm.append `_meta_data,
-   add_decl $ mk_definition meta_data_name []
-                  `(meta_data) eldt-/
 
 @[user_command]
 meta def unfinished_cmd (meta_info : decl_meta_info) (_ : parse $ tk "unfinished") : lean.parser unit :=
@@ -187,26 +169,10 @@ do nm ← ident,
    add_unfinished nm tp struct
 
 
-#check @user_attribute
-#check meta_data
-#check lean.parser.pexpr
-
-/-meta def meta_data_cache_aux (f : name → tactic pexpr) : user_attribute_cache_cfg (rb_map name meta_data) :=
-{ mk_cache := λ l, rb_map.of_list <$> l.mmap (λ n, do mdp ← f n, md ← to_expr mdp >>= eval_expr meta_data, return (n, md)),
-  dependencies := [] }-/
-
-
-
 meta def print_all_unfinished : command :=
 do ns ← attribute.get_instances `unfinished,
    ns.mmap (λ n, do trace n, get_meta_data n >>= trace),
    return ()
-
-
-open expr
-
-/-meta def print_unfinished_dependencies_aux : expr → command
-| (const nm _) := (has_attribute `unfinished nm >> (do trace nm, get_meta_data nm >>= trace)) <|> -/
 
 
 end user_commands

--- a/meta_data.lean
+++ b/meta_data.lean
@@ -137,7 +137,7 @@ section user_commands
 open lean.parser tactic interactive
 
 @[user_attribute] meta def meta_data_tag : user_attribute unit pexpr :=
-{ name := `meta_data_tag,
+{ name := `meta_data,
   descr := "",
   parser := types.texpr,--lean.parser.pexpr,
   after_set := some (λ n _ _,
@@ -173,6 +173,5 @@ meta def print_all_unfinished : command :=
 do ns ← attribute.get_instances `unfinished,
    ns.mmap (λ n, do trace n, get_meta_data n >>= trace),
    return ()
-
 
 end user_commands

--- a/meta_data.lean
+++ b/meta_data.lean
@@ -37,9 +37,29 @@
        }
 -/
 inductive {u} result : Type (u+1)
-  | Proof : Π {P : Prop}, P → result
-  | Construction : Π {A : Type u}, A → result
-  | Conjecture : Prop → result
+| Proof : Π {P : Prop}, P → result
+| Construction : Π {A : Type u}, A → result
+| Conjecture : Prop → result
+
+
+/- A datatype describing a person, normally an author. You may leave out
+   most fields, but name has to be there. -/
+structure author :=
+(name : string)
+(institution : string := "")
+(homepage : string := "")
+(email : string := "")
+
+structure document :=
+(title : string)
+(authors : list author)
+(doi : string := "") -- write evertying starting from the DOI prefix (which is 10)
+(arxiv : string := "") -- write these as Arxiv "1707.04448"
+(url : string := "")
+(source : string := "") -- journal or book title
+(year : option nat := none)
+(reference : string := "")
+
 
 /- There will be many citations everywhere, so it is a good idea
    to introduce a datatype for them early on. Here are some typical
@@ -76,20 +96,10 @@ inductive {u} result : Type (u+1)
 
 -/
 inductive cite
-  | DOI : string → cite -- write everything starting from the DOI prefix (which is 10)
-  | Arxiv : string → cite -- write these as Arxiv "1707.04448"
-  | URL : string → cite
-  | Reference : string → cite
-  | Ibidem : cite -- refer to the primary source of a fabstract
-  | Item : cite → string → cite -- refer to specific item in a source
-
-/- A datatype describing a person, normally an author. You may leave out
-   most fields, but name has to be there. -/
-structure author :=
-    (name : string)
-    (institution : string := "")
-    (homepage : string := "")
-    (email : string := "")
+| Document : document → cite
+| Website : string → cite
+| Folklore : cite
+| Item : cite → string → cite -- refer to specific item in a source
 
 /-
 TODO: This definition forces all the results in a particular fabstract
@@ -101,12 +111,13 @@ giving multiple equivalent sources (say a journal paper and the ArXiv version)
 makes it impossible to resolve conflicts when they arise. The primary source
 is always to be taken as the official one.
 -/
-structure {u} meta_data : Type (u+1) :=
-    (description : string) -- short description of the contents
-    (authors : list author) -- list of authors
-    (primary : cite) -- primary source (the most official one)
-    (secondary : list cite := []) -- auxiliary and alternative sources (such as ArXiv equivalent)
-    (results : list (result.{u})) -- the list of results
+structure meta_data :=
+(description : string) -- short description of the contents
+(contributors : list author := []) -- list of contributors
+(sources : list cite := [])
+
+structure {u} fabstract extends meta_data :=
+(results : list (result.{u}))
 
 /-
 Users will want to assume that a certain objects exist,
@@ -116,21 +127,21 @@ constants like this, we tag them with informal descriptions
 (of what the structure is, or how the construction goes)
 and references to the literature.
 -/
-structure unfinished_meta_data :=
-    (description : string)
-    (references : list cite := [])
+/-structure unfinished_meta_data :=
+(description : string)
+(references : list cite := [])-/
 
 section user_commands
 open lean.parser tactic interactive
 
 meta def add_unfinished (nm : name) (tp data : expr ff) : command :=
 do eltp ← to_expr tp,
-   eldt ← to_expr ``(%%data : unfinished_meta_data),
+   eldt ← to_expr ``(%%data : meta_data),
    let axm := declaration.ax nm [] eltp,
    add_decl axm,
    let meta_data_name := nm.append `_meta_data,
    add_decl $ mk_definition meta_data_name []
-                  `(unfinished_meta_data) eldt
+                  `(meta_data) eldt
 
 @[user_command]
 meta def unfinished_cmd (meta_info : decl_meta_info) (_ : parse $ tk "unfinished") : lean.parser unit :=


### PR DESCRIPTION
This PR contains a proposal for reorganizing the metadata that we collect, in a way that (I think) is more in line with the discussion in #44.

(Note: don't merge this PR yet. I haven't updated the comments in `meta_data.lean`, and only changed Andrej's fabstract as an example. The project won't fully compile.)

- `result` and `author` are unchanged.
- A `document` refers to a published work -- article, book, etc. It's roughly what you would expect to find Bibtex info for on MathSciNet or Google Scholar. We may want to make the fields more closely resemble Bibtex fields, or even have different types of documents for articles, books, ...
- A `cite` is either a document, a website, a subelement of another `cite`, or "folklore". The latter will be used sparingly, I hope, but it's intended as a placeholder for results that are too obvious to give an actual document.
- `meta_data` is collected for any `unfinished` result. It contains a description of the result, a list of contributors, and a list of citations. The contributors are intended to be the formalizers, not necessarily the people who first proved the result; if these people are known, their names should be found in one of the citations.
- An `fabstract` extends `meta_data` with a list of results. If we're treating fabstracts as "arbitrary collections of mathematical knowledge," we don't want them to refer to primary/secondary sources; the list of references in `meta_data` suffices. We can also decouple the formalizer from the original prover.

I'm not committed to particular details of this organization scheme, but wanted to put it up for discussion. Obviously, the particular fields of each structure are easy to modify. It seems better to err on the side of collecting too much meta data, rather than too little, since we can make the structure fields optional.