### PR TITLE
@[fabstract ...] user attribute

### DIFF
--- a/src/tactic/fattribute.lean
+++ b/src/tactic/fattribute.lean
@@ -17,7 +17,7 @@ meta def fabstract_attr : user_attribute (rb_map name (list name)) (list name) :
 {
   name := `fabstract,
   descr := "The fabstract user attribute. Used to mark lemmas captured and also to store the 2010 MSC classification.",
-  parser := list_of ident,
+  parser := list_of ident <|> pure [],
   cache_cfg := ⟨ λ l, l.mfoldl (λ m n, do
       tags ← fabstract_attr.get_param n,
       return $ tags.foldl (λ m t, m.insert_cons t n) m) mk_rb_map
@@ -42,8 +42,7 @@ def welp : 1+1 =2 := by simp
 @[fabstract [JBX190,AXX200]] 
 def woolp : 1+1 =2 := by simp
 
-/- TODO: fix this garbage. -/
-@[fabstract[]] 
+@[fabstract] 
 def flump : 1+1 =2 := by simp
 
 run_cmd attribute.get_instances `fabstract >>= tactic.trace

--- a/src/tactic/fattribute.lean
+++ b/src/tactic/fattribute.lean
@@ -49,7 +49,7 @@ run_cmd attribute.get_instances `fabstract >>= tactic.trace
 
 meta def get_MSC_codes (n : name) : tactic (list name) := user_attribute.get_param fabstract_attr n
 
-run_cmd doc_string `test₁ >>= tactic.trace >>                  get_MSC_codes `test₁ >>= tactic.trace 
+run_cmd doc_string `test₁ >>= tactic.trace >> get_MSC_codes `test₁ >>= tactic.trace 
 
 /- Gives all declarations with a particular MSC code.-/
 run_cmd do 

--- a/src/tactic/fattribute.lean
+++ b/src/tactic/fattribute.lean
@@ -11,44 +11,38 @@ import tactic.ext
 
 open interactive interactive.types lean.parser tactic native
 
--- #check name_map
 @[user_attribute]
 meta def fabstract_attr : user_attribute (rb_map name (list name)) (list name) :=
 {
   name := `fabstract,
   descr := "The fabstract user attribute. Used to mark lemmas captured and also to store the 2010 MSC classification.",
-  parser := list_of ident <|> pure [],
+  parser := many ident <|> pure [],
   cache_cfg := ⟨ λ l, l.mfoldl (λ m n, do
       tags ← fabstract_attr.get_param n,
       return $ tags.foldl (λ m t, m.insert_cons t n) m) mk_rb_map
    , [] ⟩
-  -- cache_cfg := ⟨ λ l, l.mfoldl (λ m n, do
-  --     d ← get_decl n, 
-  --     v ← fabstract_attr.get_param n,
-  --     return (m.insert n v)) mk_rb_map
-  --  , [] ⟩ 
 } 
 
 /-- Well, hello there! -/
-@[fabstract [ABC000,ABC200]] 
+@[fabstract ABC000 ABC200] 
 def test₁ : 1+1 =2 := by simp
 
-@[fabstract [ABC101,ABC200]] 
+@[fabstract ABC101 ABC200] 
 def test₂ : 1+1 =2 := by simp
 
-@[fabstract [ABC101,XYZ200]] 
+@[fabstract ABC101 XYZ200] 
 def welp : 1+1 =2 := by simp
 
-@[fabstract [JBX190,AXX200]] 
+@[fabstract JBX190 AXX200] 
 def woolp : 1+1 =2 := by simp
 
 @[fabstract] 
 def flump : 1+1 =2 := by simp
 
-run_cmd attribute.get_instances `fabstract >>= tactic.trace
-
 meta def get_MSC_codes (n : name) : tactic (list name) := user_attribute.get_param fabstract_attr n
 
+/- Tests -/
+run_cmd attribute.get_instances `fabstract >>= tactic.trace
 run_cmd doc_string `test₁ >>= tactic.trace >> get_MSC_codes `test₁ >>= tactic.trace 
 
 /- Gives all declarations with a particular MSC code.-/

--- a/src/tactic/fattribute.lean
+++ b/src/tactic/fattribute.lean
@@ -10,6 +10,7 @@ import tactic.basic
 import tactic.ext 
 
 open interactive interactive.types lean.parser tactic native
+
 -- #check name_map
 @[user_attribute]
 meta def fabstract_attr : user_attribute (rb_map name (list name)) (list name) :=
@@ -18,10 +19,14 @@ meta def fabstract_attr : user_attribute (rb_map name (list name)) (list name) :
   descr := "The fabstract user attribute. Used to mark lemmas captured and also to store the 2010 MSC classification.",
   parser := list_of ident,
   cache_cfg := ⟨ λ l, l.mfoldl (λ m n, do
-      d ← get_decl n, 
-      v ← fabstract_attr.get_param n,
-      return (m.insert n v)) mk_rb_map
-   , [] ⟩ 
+      tags ← fabstract_attr.get_param n,
+      return $ tags.foldl (λ m t, m.insert_cons t n) m) mk_rb_map
+   , [] ⟩
+  -- cache_cfg := ⟨ λ l, l.mfoldl (λ m n, do
+  --     d ← get_decl n, 
+  --     v ← fabstract_attr.get_param n,
+  --     return (m.insert n v)) mk_rb_map
+  --  , [] ⟩ 
 } 
 
 /-- Well, hello there! -/
@@ -41,11 +46,14 @@ def woolp : 1+1 =2 := by simp
 @[fabstract[]] 
 def flump : 1+1 =2 := by simp
 
+run_cmd attribute.get_instances `fabstract >>= tactic.trace
+
 meta def get_MSC_codes (n : name) : tactic (list name) := user_attribute.get_param fabstract_attr n
 
 run_cmd doc_string `test₁ >>= tactic.trace >>                  get_MSC_codes `test₁ >>= tactic.trace 
 
+/- Gives all declarations with a particular MSC code.-/
 run_cmd do 
   m ← fabstract_attr.get_cache,
-  v ← m.find `woolp,
-  trace m
+  v ← m.find `ABC101,
+  trace v

--- a/src/tactic/fattribute.lean
+++ b/src/tactic/fattribute.lean
@@ -37,6 +37,10 @@ def welp : 1+1 =2 := by simp
 @[fabstract [JBX190,AXX200]] 
 def woolp : 1+1 =2 := by simp
 
+/- TODO: fix this garbage. -/
+@[fabstract[]] 
+def flump : 1+1 =2 := by simp
+
 meta def get_MSC_codes (n : name) : tactic (list name) := user_attribute.get_param fabstract_attr n
 
 run_cmd doc_string `test₁ >>= tactic.trace >>                  get_MSC_codes `test₁ >>= tactic.trace 
@@ -44,4 +48,4 @@ run_cmd doc_string `test₁ >>= tactic.trace >>                  get_MSC_codes `
 run_cmd do 
   m ← fabstract_attr.get_cache,
   v ← m.find `woolp,
-  trace v
+  trace m

--- a/src/tactic/fattribute.lean
+++ b/src/tactic/fattribute.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2018 Koundinya Vajjha. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Koundinya Vajjha
+
+The fabstract user attribute. 
+-/
+
+import tactic.basic 
+import tactic.ext 
+
+open interactive interactive.types lean.parser tactic
+
+@[user_attribute]
+meta def fabstract_attr : user_attribute unit (list name) :=
+{
+  name := `fabstract,
+  descr := "The fabstract user attribute. Used to mark lemmas captured and also to store the 2010 MSC classification.",
+  parser := list_of ident
+} 
+
+/-- Well, hello there! -/
+@[fabstract [ABC000,ABC200]] 
+def test : 1+1 =2 := by simp
+
+
+meta def get_MSC_codes (n : name) : tactic (list name) := user_attribute.get_param fabstract_attr n
+
+run_cmd doc_string `test >>= tactic.trace >>                   get_MSC_codes `test >>= tactic.trace 
+


### PR DESCRIPTION
Added a user attribute which also takes in an arbitrary number of [MSC 2010 classification](https://mathscinet.ams.org/msc/pdfs/classifications2010.pdf) codes as parameters. 